### PR TITLE
Cast the success and failure constant macros

### DIFF
--- a/visca/libvisca.h
+++ b/visca/libvisca.h
@@ -337,8 +337,8 @@
 /***************/
 
 /* these two are defined by me, not by the specs. */
-#define VISCA_SUCCESS 0x00
-#define VISCA_FAILURE 0xFF
+#define VISCA_SUCCESS ((uint32_t)0x00)
+#define VISCA_FAILURE ((uint32_t)0xFF)
 
 /* specs errors: */
 #define VISCA_ERROR_MESSAGE_LENGTH 0x01


### PR DESCRIPTION

### Description
<!--- Describe what was changed, why the change is required, what problem to be solved. -->

When returning these macros inside a functor in C++, return type becomes `int`, where expecting `uint32_t` since other functions returns `uint32_t`.
To avoid this, add type-cast of these macros.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- If something is not checked, please also describe it. -->

CI will test.

<!-- If unsure, feel free to let them unchecked. -->
### General checklist
- [ ] The commit is reviewed by yourself.
- [ ] The code is tested.
- [ ] Document is up to date or not necessary to be changed.
- [ ] The commit is compatible with repository's license.
